### PR TITLE
fix a bug in csvwriter if number of events if equal to mempool-max-events-num, which results in TypeError: map argument #1 must support iteration

### DIFF
--- a/clickhouse_mysql/writer/csvwriter.py
+++ b/clickhouse_mysql/writer/csvwriter.py
@@ -134,7 +134,7 @@ class CSVWriter(Writer):
                 self.writer.writerow(self.convert(row))
 
     def push(self):
-        if not self.next_writer_builder:
+        if not self.next_writer_builder or not self.fieldnames:
             return
 
         event = Event()


### PR DESCRIPTION
Hello,

I've recently discovered, that in case of number of events is equal to mempool-max-events-num and the following error occurs - "map argument #1 must support iteration" (see #141).

clickhouse-mysql was ran with following params:
```clickhouse-mysql --src-server-id=26940928 --src-resume --src-wait --nice-pause=1 --src-host=host1 --src-user=ch_reader --src-password=password --src-tables=db1.tbl1,db1.tbl2 --dst-host=127.0.0.1 --csvpool --csvpool-file-path-prefix=/tmp/ch_ --mempool-max-flush-interval=60 --mempool-max-events-num=100 --binlog-position-file=/tmp/binlog.txt --pump-data```

the problem was related to push method in csvwriter.py. We always initialize and create new event, even if in insert method we find out that there is no events to insert and returned.