### PR TITLE
set exit code 1 for run too

### DIFF
--- a/clickhouse_mysql/main.py
+++ b/clickhouse_mysql/main.py
@@ -153,6 +153,7 @@ class Main(Daemon):
             traceback.print_exc(file=sys.stdout)
             print('=============')
             print(ex)
+            sys.exit(1);
 
     def start(self):
         if self.config.is_daemon():


### PR DESCRIPTION
We use clickhouse-mysql as part of an automation script and we need to know if it has failed or not. I see that for the install part the exit code is set, but not for the run part.