### PR TITLE
fix #194: NoneType' object has no attribute 'encode'

### DIFF
--- a/clickhouse_mysql/writer/chwriter.py
+++ b/clickhouse_mysql/writer/chwriter.py
@@ -74,6 +74,7 @@ class CHWriter(Writer):
             event_converted = self.convert(event)
             for row in event_converted:
                 for key in row.keys():
+                    row[key] = '' if row[key] is None else row[key]
                     # we need to convert Decimal value to str value for suitable for table structure
                     if type(row[key]) == Decimal:
                         row[key] = str(row[key])


### PR DESCRIPTION
fixed #194 - thanks to @FessAectan for his [patch](https://github.com/Altinity/clickhouse-mysql-data-reader/issues/194#issuecomment-933469329). 
